### PR TITLE
Turning off localization to fix datepicker when field as initial value

### DIFF
--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -1,4 +1,5 @@
 {% load materializecss %}
+{% load l10n %}
 
 
     {% if field|is_checkbox %}
@@ -53,7 +54,7 @@
             <i class="material-icons prefix">{{ classes.icon }}</i>
         {% endif %}
 
-        <input type="date" id="{{ field.auto_id }}" name="{{ field.html_name }}" class="datepicker" value="{% if field.value %}{{ field.value }}{% endif %}" {% include 'materializecssform/attrs.html' %} >
+        <input type="date" id="{{ field.auto_id }}" name="{{ field.html_name }}" class="datepicker" value="{% if field.value %}{% localize off %}{{ field.value }}{% endlocalize %}{% endif %}" {% include 'materializecssform/attrs.html' %} >
         <label for="{{ field.id_for_label }}">{{ field.label }}</label>
 
         {% for error in field.errors %}


### PR DESCRIPTION
So when using the form as an edit/update form, django puts in a localized value that the datepicker does not like.  By turning off that just where - well see changes - then it works.